### PR TITLE
Add layout css file with grid layout and add site title

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
 <link rel="stylesheet" href="/css/main.css">
+<link rel="stylesheet" href="/css/layout.css">
 {% for stylesheet in page.styles %}
     <link rel="stylesheet" href="/css/{{ stylesheet }}.css">
 {% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,11 +1,16 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        {% include head.html %}
-    </head>
-    <body>
-        {% include header.html %}
-        {% include banner.html %}
+
+<head>
+    {% include head.html %}
+</head>
+
+<body>
+    {% include header.html %}
+    {% include banner.html %}
+    <main>
         {{ content }}
-    </body>
+    </main>
+</body>
+
 </html>

--- a/css/index.css
+++ b/css/index.css
@@ -1,0 +1,44 @@
+main {
+    background-color: var(--beige);
+    --site-title-height: calc(65px * 12);
+    min-height: var(--site-title-height);
+    padding-top: 75px;
+}
+
+span.site-title {
+    position: absolute;
+    left: 110px;
+    color: var(--turquoise);
+    writing-mode: vertical-rl;
+    font-size: 65px;
+    justify-self: center;
+    height: var(--site-title-height);
+    transform: translateY(-225px);
+}
+
+span.site-title > .line {
+    display: block;
+    text-align: center;
+}
+
+span.site-title > .line:first-child {
+    text-indent: 110px;
+    text-align: start;
+}
+
+span.site-title > .line:nth-child(2) {
+    text-indent: 50px;
+    text-align: start;
+}
+
+span.site-title .emphasized {
+    color: var(--lime);
+    font-style: italic;
+    font-family: serif;
+}
+
+@media only screen and (max-width: 900px) {
+    span.site-title {
+        display: none;
+    }
+}

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,0 +1,29 @@
+main {
+    display: grid;
+    width: 100%;
+    grid-template-columns: [callout] 3fr [article] 7fr;
+    grid-auto-flow: row;
+    padding: 40px 50px;
+    gap: 20px 40px;
+}
+
+main > :not(.callout) {
+    grid-column: article / end;
+    overflow: hidden;
+    font-size: 20px;
+    line-height: 1.25;
+    justify-content: end;
+}
+
+main > .callout {
+    grid-column: callout / article;
+    text-align: right;
+    justify-self: right;
+}
+
+@media only screen and (max-width: 900px) {
+    main {
+        grid-auto-flow: column;
+        grid-template-columns: [callout] 100% [article];
+    }
+}

--- a/css/main.css
+++ b/css/main.css
@@ -2,19 +2,23 @@
     --sans: -apple-system, BlinkMacSystemFont, "Avenir Next", Avenir, Helvetica, "Helvetica Neue", Ubuntu, Roboto, Noto, "Segoe UI", Arial, sans-serif;
     --serif: "New York", Charter, Georgia, Cambria, "Times New Roman", Times, serif;
     --mono: San Francisco Mono, Monaco, "Consolas", "Lucida Console", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
-    --turqoise: rgb(67, 170, 144);
+    --turquoise: rgb(67, 170, 144);
     --orange: rgb(241, 141, 0);
     --lime: rgb(157, 200, 21);
-    --primary: var(--turqoise);
+    --beige: rgb(255, 249, 226);
+    --gray: rgb(114, 113, 114);
+    --primary: var(--turquoise);
     --secondary: var(--orange);
     --tertiary: var(--lime);
+    --background-color: var(--beige);
+    --text-color: var(--gray);
 }
 *, *::before, *::after {
     box-sizing: border-box;
+    margin: 0px;
 }
 body {
     font-family: var(--serif);
-    padding-bottom: 20px;
     margin: 0px;
 }
 h1, h2, h3, h4, h5, h6 {
@@ -23,12 +27,24 @@ h1, h2, h3, h4, h5, h6 {
 h1 {
     color: white;
 }
+h2 {
+    color: var(--turquoise);
+}
+h3 {
+    color: var(--lime);
+}
 a {
     color: var(--tertiary);
+}
+p {
+    color: var(--text-color);
 }
 nav {
     transition: box-shadow 0.3s;
     text-align: center;
+}
+nav img {
+    width: 400px;
 }
 nav ul {
     vertical-align: top;
@@ -81,7 +97,7 @@ blockquote {
     height: var(--banner-height);
     /* Box width is the box + its before width */
     --box-width: 20vw;
-    background-color: black;
+    background-color: var(--turquoise);
     --color-box-width: 20vw;
 }
 #banner > div.img {
@@ -120,7 +136,7 @@ blockquote {
     /* These values are based on the width and height of the banner */
     border-width: calc(var(--banner-height) / 2) calc(var(--color-box-width) / 2);
     border-top-color: var(--orange);
-    border-left-color: var(--turqoise);
+    border-left-color: var(--turquoise);
     border-bottom-color: var(--lime);
 }
 #banner.title {
@@ -135,7 +151,7 @@ blockquote {
     position: absolute;
     top: 0;
     left: 0;
-    background-color: var(--turqoise);
+    background-color: var(--turquoise);
     width: calc(var(--box-width) - var(--color-box-width));
     height: 100%;
 }

--- a/index.md
+++ b/index.md
@@ -1,11 +1,14 @@
 ---
 layout: default
 banner-image: /assets/images/slider/dc-21.jpg
+styles:
+    - index
 ---
-# About WCIE
-## Need to add image slider
+{::nomarkdown}
+<span class="callout site-title"><span class="line">Washington Center <span class="emphasized">for</span></span> <span class="line">International</span> <span class="line">Eduction</span></span>
+{:/nomarkdown}
 
-**WCIE invites students to engage with each other and their world. Our purpose is active learning and service in community; and our programs are internationally-oriented and designed to inspire.**
+### WCIE invites students to engage with each other and their world. Our purpose is active learning and service in community; and our programs are internationally-oriented and designed to inspire.
 
 We all need to come together to address the world’s most pressing challenges. WCIE programs address tough topics like [racism](https://washingtoncie.org/community-service-and-ssl/youth-facing-racism/), the [global migration and refugee crisis](https://washingtoncie.org/community-service-and-ssl/youth-facing-the-global-migration-and-refugee-crisis/), and [conservation and the environment](https://washingtoncie.org/community-service-and-ssl/youth-facing-the-global-freshwater-crisis/). We take a holistic approach to intellectual, social, and emotional growth. We serve the student, and we hope to reach students’ families as well.
 


### PR DESCRIPTION
This adds the grid layout that should make up most pages on the site. Essentially, each `<h3>` and `<p>` section should be grouped in a `<section>` block. All `<section>` blocks will then appear on the right of the screen, and if any other block has the class "callout" it will appear on the left of the next block in the layout. So you could give an image that class, and it would appear on the left of the following section. On mobile, they should shrink to a single column (currently with the images going *above* the text, when they should go below. I'll make an issue for that).